### PR TITLE
Add options and variables to limit HA.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,15 @@ variable "vault_ui" {
   type        = bool
   default     = false
 }
+
+variable "container_concurrency" {
+  description = "Max number of connections per container instance."
+  type        = number
+  default     = 80 # Max per Cloud Run Documentation
+}
+
+variable "vault_api_addr" {
+  description = "Full HTTP endpoint of Vault Server if using a custom domain name. Leave blank otherwise."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
The PR creates three new variables to control storage HA settings and container scaling. Defaults disable storage HA, limits container scaling to 1, limits requests per container to 80 (current max). 

Refs: 
* https://www.vaultproject.io/docs/configuration/storage/google-cloud-storage
* https://cloud.google.com/run/docs/about-concurrency
