### PR TITLE
Working with google provider v4.1.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ resource "google_service_account" "vault" {
 resource "google_storage_bucket" "vault" {
   name          = local.vault_storage_bucket_name
   project       = var.project
+  location      = var.vault_storage_bucket_location
   force_destroy = var.bucket_force_destroy
 }
 
@@ -63,7 +64,7 @@ resource "google_kms_key_ring" "vault" {
 # Create a crypto key for the key ring, rotate daily
 resource "google_kms_crypto_key" "vault" {
   name            = "${var.name}-key"
-  key_ring        = google_kms_key_ring.vault.self_link
+  key_ring        = google_kms_key_ring.vault.id
   rotation_period = var.vault_kms_key_rotation
 
   version_template {

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,9 @@ variable "vault_storage_bucket_name" {
   type        = string
   default     = ""
 }
+
+variable "vault_storage_bucket_location" {
+  description = "The GCS location of the storage bucket"
+  type        = string
+  default     = "US"
+}


### PR DESCRIPTION
This solves issue #9 

Please review the changes, as they're pretty straightforward. The change from `self-link` to `id` in particular should work with version 3.x according to the [provider's documentation](https://registry.terraform.io/providers/hashicorp/google/3.89.0/docs/resources/kms_key_ring).